### PR TITLE
Add support for bracket expressions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ lib:
 clean:
 	$(OCAMLBUILD) -clean
 
-test: short-tests regenerate-tests
+test: short-tests regenerate-tests qcheck-tests
 	$(OCAMLBUILD) tests.native
 	./tests.native
 
@@ -23,6 +23,10 @@ short-tests:
 regenerate-tests:
 	$(OCAMLBUILD) regenerate_tests.native
 	./regenerate_tests.native
+
+qcheck-tests:
+	$(OCAMLBUILD) qcheck_tests.native
+	./qcheck_tests.native
 
 install: lib binary
 	$(OCAMLFIND) install re-nfa META	\

--- a/_tags
+++ b/_tags
@@ -5,5 +5,6 @@
 <src/*.*>: warn(-24)
 
 <lib_test/regenerate_tests.*>: package(qcheck regenerate)
+<lib_test/qcheck_tests.*>: package(qcheck)
 
 

--- a/lib/regex.ml
+++ b/lib/regex.ml
@@ -7,6 +7,7 @@ open Nfa
      to prevent a state explosion.)
  *)
 module C = Set.Make(Char)
+type charset = C.t
 
 (** A 'letter' is a character set paired with an identifier that
     uniquely identifies the character set within the regex *)
@@ -196,6 +197,8 @@ let chr c = Char (C.singleton c)
 let opt t = alt t eps
 let empty = Empty
 
+let oneof cs = match C.cardinal cs with 0 -> Empty | _ -> Char cs
+
 let range_ l h =
   let rec loop i h acc =
     if i = h then         C.add (Char.chr i) acc
@@ -203,13 +206,123 @@ let range_ l h =
   in loop (Char.code l) (Char.code h) C.empty
 
 let range l h = Char (range_ l h)
-let any = range (Char.chr 0) (Char.chr 255)
+let any_ = range_ (Char.chr 0) (Char.chr 255)
+let any = Char any_
 
 exception Parse_error of string
 
 module Parse =
 struct
   exception Fail
+
+  module Bracket =
+  struct
+    (** Follows the POSIX spec
+          9.3.5 RE Bracket Expression
+           http://pubs.opengroup.org/onlinepubs/009696899/basedefs/xbd_chap09.html#tag_09_03_05
+        but there is currently no support for character classes.
+
+        Bracket expressions are delimited by [ and ], with an optional "complement"
+        operator ^ immediately after the [.  Special characters:
+           ^ (immediately after the opening [)
+           ] (except immediately after the opening [ or [^)
+           - (except at the beginning or end)                                   *)
+
+    type element = Char of char | Range of char * char
+    type t = { negated: bool; elements: element list }
+
+    let interpret { negated; elements } =
+      let s =
+        List.fold_right
+          (function Char c -> C.add c
+                  | Range (c1,c2) -> C.union (range_ c1 c2))
+          elements C.empty in
+      if negated then C.diff any_ s
+      else s
+
+    let parse_element = function
+      | [] -> raise Fail
+      | ']' :: s -> (None, s)
+      | c :: ('-' :: ']' :: _ as s) -> (Some (Char c), s)
+      | c1 :: '-' :: c2 :: s -> (Some (Range (c1, c2)), s)
+      | c :: s -> (Some (Char c), s)
+
+    let parse_initial = function
+      | [] -> raise Fail
+      | c :: ('-' :: ']' :: _ as s) -> (Some (Char c), s)
+      | c1 :: '-' :: c2 :: s -> (Some (Range (c1, c2)), s)
+      | c :: s -> (Some (Char c), s)
+
+    let parse_elements s = 
+      let rec loop elements s =
+        match parse_element s with
+        | None, s -> (List.rev elements, s)
+        | Some e, s -> loop (e :: elements) s in
+      match parse_initial s with
+      | None, s -> ([], s)
+      | Some e, s -> loop [e] s
+
+    type result = { hyphen: bool;
+                    caret: bool;
+                    lbracket: bool;
+                    ranges: (char * char) list; }
+    let ranges (set : C.t) =
+      let adjacent c1 c2 = abs (Char.code c1 - Char.code c2) = 1 in
+      match
+        C.fold
+          (fun c (co, r) ->
+            match c, co with
+            | '-', co -> (co, {r with hyphen = true})
+            | '^', co -> (co, {r with caret = true})
+            | ']', co -> (co, {r with lbracket = true})
+            | c, None -> (Some (c,c), r) 
+            | c, Some (c1,c2) when adjacent c c2 -> (Some (c1, c), r)
+            | c, Some (c1,c2) -> (Some (c,c),
+                                  { r with ranges = (c1,c2) :: r.ranges }))
+          set
+          (None, {hyphen = false; caret = false; lbracket = false; ranges = []})
+      with
+      | None  , r -> {r with ranges = List.rev r.ranges}
+      | Some p, r -> {r with ranges = List.rev (p :: r.ranges)}
+
+    let regex_specials = "*+?.|()["
+
+    let unparse ?(complement=false) (set : C.t) =
+      let pr = Printf.sprintf in
+      let r = ranges set in
+      let conc =
+        List.fold_left
+          (fun s (x,y) -> if x = y then pr "%c%s" x s
+                          else pr "%c-%c%s" x y s)
+          "" in
+      let whenever p s = if p then s else "" in
+      let bracket s = if complement then pr "[^%s]" s else pr "[%s]" s in
+      match r.ranges, r.lbracket, r.caret, r.hyphen with
+      | [(x,y)], false, false, false
+          (* If we have a single non-special character then
+             there's no need for a range expression *)
+           when x = y
+             && not complement
+             && not (String.contains regex_specials x) -> pr "%c" x
+      | _ :: _ as rs, lbracket, caret, hyphen ->
+         (* If we have some non-special characters then we don't need to
+            take extra care to avoid accidentally positioning special
+            characters like ^ the beginning or end *)
+         bracket @@
+         pr "%s%s%s%s"
+           (whenever lbracket "]")
+           (conc rs)
+           (whenever caret "^")
+           (whenever hyphen "-")
+      | [], true, _, _ ->
+         bracket (pr "]%s%s" (whenever r.caret "^") (whenever r.hyphen "-"))
+      | [], false, true , true  -> bracket "-^"
+      | [], false, true , false -> if complement then "[^^]" else "^"
+      | [], false, false, true  -> bracket "-"
+      | [], false, false, false -> pr "[%s%c-%c]"
+                                     (if complement then "" else "^")
+                                     (Char.chr 0) (Char.chr 255)
+  end
 
   type t =
     | Opt : t -> t
@@ -218,6 +331,7 @@ struct
     | Seq : t * t -> t
     | Star : t -> t
     | Plus : t -> t
+    | Bracketed : Bracket.t -> t
     | Any : t
     | Eps : t
 
@@ -228,11 +342,22 @@ struct
     | Seq (l, r) -> seq (interpret l) (interpret r)
     | Star t -> star (interpret t)
     | Plus t -> plus (interpret t)
+    | Bracketed elements -> Char (Bracket.interpret elements)
     | Any -> any
     | Eps -> eps
 
+   (* We've seen [.  Special characters:
+        ^   (beginning of negation)  *)
+  let re_parse_bracketed : char list -> (t * char list) = function
+    | '^' :: s -> let elements, rest = Bracket.parse_elements s in
+                  (Bracketed { negated = true; elements }, rest)
+    | _ :: _ as s -> let elements, rest = Bracket.parse_elements s in
+                (Bracketed { negated = false; elements }, rest)
+    | [] -> raise Fail
+
   (** ratom ::= .
                 <character>
+                [ bracket ]
                 ( ralt )           *)
   let rec re_parse_atom : char list -> (t * char list) option = function
     | '('::rest ->
@@ -240,6 +365,7 @@ struct
        | (r, ')' :: rest) -> Some (r, rest)
        | _ -> raise Fail
        end
+    | '['::rest -> Some (re_parse_bracketed rest)
     | [] | ((')'|'|'|'*'|'?'|'+') :: _) -> None
     | '.' :: rest -> Some (Any, rest)
     | h :: rest -> Some (Chr h, rest)
@@ -283,3 +409,9 @@ struct
 end
 
 let parse s = Parse.(interpret (parse s))
+
+let unparse_charset s =
+  let pos = Parse.Bracket.unparse ~complement:false s
+  and neg = Parse.Bracket.unparse ~complement:true (C.diff any_ s) in
+  if String.length pos <= String.length neg then pos else neg
+              

--- a/lib/regex.mli
+++ b/lib/regex.mli
@@ -3,6 +3,9 @@
 type t
 (** The type of regular expressions *)
 
+type charset = Set.Make(Char).t
+(** Sets of characters *)
+
 val empty : t
 (** [empty] rejects every string *)
 
@@ -11,6 +14,9 @@ val eps : t
 
 val any : t
 (** [any] accepts any single character *)
+
+val oneof : charset -> t
+(** [oneof cs] accepts any character in cs *)
 
 val range : char -> char -> t
 (** [range l h] accepts any character in the range [l]..[h] *)
@@ -47,9 +53,14 @@ val parse : string -> t
             r*           (zero or more)
             r+           (one or more)
             c            (literal character)
+            [b]          (POSIX bracket expression)
 
    Raises [Parse_error] on parse error
 *)
+
+val unparse_charset : charset -> string
+(** [unparse_charset cs] is a string denoting a regular expression
+    that accepts any character in [cs], and nothing else *)
 
 val compile : t -> Nfa.nfa
 (** [compile r] translates [r] to an NFA that succeeds on exactly

--- a/lib_test/qcheck_tests.ml
+++ b/lib_test/qcheck_tests.ml
@@ -1,0 +1,74 @@
+open Tests_common
+
+module C = Set.Make(Char)
+
+let complement set =
+  let rec loop acc i =
+    if i > 255 then acc else
+      let c = Char.chr i in
+      if C.mem c set then loop acc (succ i)
+      else loop (C.add c acc) (succ i)
+  in loop C.empty 0
+
+let check_all set f = C.for_all f set && not (C.exists f (complement set))
+
+let showset set = C.fold (Printf.sprintf "%c%s") set ""
+
+let all_chars = C.elements (complement C.empty)
+let take i l =
+  let rec loop acc i l =
+    match i, l with
+    | 0, _ |  _, [] -> List.rev acc
+    | i, h :: t -> loop (h :: acc) (pred i) t
+  in loop [] i l
+
+let charset_gen =
+  let open QCheck.Gen in
+  int_bound 255 >>= fun cardinal ->
+  map (take cardinal) (shuffle_l all_chars) >>= fun l ->
+  return (C.of_list l)
+
+let charset = QCheck.make charset_gen
+
+let check_essential_property set : bool =
+  let unparsed = (Regex.unparse_charset set) in
+  check_all set @@ fun c ->
+  nfa_accept (Regex.compile (Regex.parse unparsed)) (String.make 1 c)
+
+let roundtrip_test =
+  QCheck.Test.make ~count:10000 ~name:"parse (unparse s) = oneof s" charset check_essential_property
+
+let roundtrip_test0 () =
+  assert (check_essential_property C.empty)
+
+let roundtrip_test1 () =
+  for i = 0 to 255 do
+    assert (check_essential_property (C.singleton (Char.chr i)))
+  done
+
+let roundtrip_test2 () =
+  for i = 0 to 255 do
+    for j = 0 to 255 do
+      assert (check_essential_property (C.of_list [Char.chr i;
+                                                   Char.chr j]))
+    done
+  done
+
+let () =
+  begin
+    print_string "character range size 0 tests..."; flush stdout;
+    roundtrip_test0 ();
+    print_endline "OK!";
+
+    print_string "character range size 1 tests..."; flush stdout;
+    roundtrip_test1 ();
+    print_endline "OK!";
+
+    print_string "character range size 2 tests..."; flush stdout;
+    roundtrip_test2 ();
+    print_endline "OK!";
+
+    print_string "character range qcheck tests..."; flush stdout;
+    QCheck.Test.check_exn roundtrip_test;
+    print_endline "OK!";
+  end

--- a/lib_test/tests.ml
+++ b/lib_test/tests.ml
@@ -94,7 +94,56 @@ let test compile =
     assert (anothingnothingbnothingc "ac");
     assert (anothingnothingbnothingc "abc");
     assert (not (anothingnothingbnothingc "a|c"));
+
+    (* Character sets *)
+    let rbracket = compile "a[]]b" in
+    assert (rbracket "a]b");
+    assert (not (rbracket "ab"));
+    assert (not (rbracket "a[b"));
+
+    let notrbracket = compile "a[^]]b" in
+    assert (not (notrbracket "a]b"));
+    assert (notrbracket "a.b");
+    assert (notrbracket "a-b");
+    assert (notrbracket "a[b");
+
+    let alphanum = compile "[a-zA-Z0-9]+" in
+    assert (alphanum "abcDEF789");
+    assert (alphanum "Zz0");
+    assert (not (alphanum "abcDE?F789"));
+    assert (not (alphanum ""));
+
+    let hyphen = compile "[--]" in
+    assert (hyphen "-");
+    assert (not (hyphen "--"));
+    assert (not (hyphen ""));
+    assert (not (hyphen "a"));
+
+    let acaret = compile "[a^]" in
+    assert (acaret "a");
+    assert (acaret "^");
+    assert (not (acaret "b"));
+
+    let acarethyphen = compile "c[a^-]d" in
+    assert (acarethyphen "cad");
+    assert (acarethyphen "c^d");
+    assert (acarethyphen "c-d");
+    assert (not (acarethyphen "cbd"));
+
+    let nonalphanum = compile "[^0-9A-Za-z]+" in
+    assert (nonalphanum "?.%");
+    assert (not (nonalphanum "a0e"));
+
+    let metas = compile "a[]\\d^-]b" in
+    assert (metas "a]b");
+    assert (metas "a\\b");
+    assert (metas "adb");
+    assert (metas "a^b");
+    assert (metas "a-b");
+    assert (not (metas "ab"));
+    assert (not (metas "a?b"));
   end
+
 
 let () =
   begin

--- a/opam
+++ b/opam
@@ -16,6 +16,7 @@ depends: [
    "ocaml" {>= "4.02.0"}
    "ocamlfind" {build}
    "ocamlbuild" {build}
+#  "qcheck" {with-test}
 #  "regenerate" {with-test}
 ]
 synopsis: "Construct NFAs and DFAs from regular expressions"


### PR DESCRIPTION
This PR adds basic support for [POSIX bracket expressions](http://pubs.opengroup.org/onlinepubs/009696899/basedefs/xbd_chap09.html#tag_09_03_05) such as:

* `[a-zA-Z0-9]`
* `[^\n\r\t]`
* `[aceghi-z]`

Both parsing (parsing a bracket expression as part of a regular expression) and unparsing (turning a set of `char` into a bracket expression are supported.  Both directions involve some care to correctly handle characters that have special meaning either in regular expressions (e.g. `.`, `|`, `*`) or in bracket expressions (`]`, `^`, `-`).  For example,

  * `^` has a special meaning (complement) at the beginning of a bracket expression, but not elsewhere
  * `-` has a special meaning (range) *except* at the beginning or end of a bracket expression
  * `]` has a special meaning (terminate the bracket expression) *except* at the beginning of a bracket expression (i.e. after the opening `[` or `[^`)

Unparsing prefers shorter output expressions: for example, for the set of all characters except `e` unparsing returns `[^e]`, not `[\000-df-\255]`.